### PR TITLE
[In Progress] Make a Cython version of DLA log model evidence integration

### DIFF
--- a/gpy_dla_detection/fast_dla_log_model_evidence.pyx
+++ b/gpy_dla_detection/fast_dla_log_model_evidence.pyx
@@ -1,0 +1,324 @@
+''''
+Cython log model evidence calculations
+'''
+import numpy as np
+from gpy_dla_detection.null_gp import NullGP
+import scipy
+from gpy_dla_detection.voigt import voigt_absorption
+from libc.math cimport exp as c_exp
+# from cython.parallel import prange
+
+
+# # to retain only unmasked pixels from computed absorption profile
+# mask_ind = ~self.pixel_mask[self.ind]
+
+def this_dla_gp(
+    double[:] z_dlas,
+    double[:] nhis,
+    double[:] padded_wavelengths,
+    double[:] this_mu,
+    double[:, :] this_M,
+    double[:] this_omega2,
+    long[:] mask_index, # np.where(mask_ind)[0]
+    int num_lines,
+):
+    """
+    Compute the DLA GP model with k intervening DLA profiles onto
+    the mean and covariance.
+
+    :param z_dlas: (k_dlas, ), the redshifts of intervening DLAs
+    :param nhis: (k_dlas, ), the column densities of intervening DLAs
+
+    :return: (dla_mu, dla_M, dla_omega2)
+    :return dla_mu: (n_points, ), the GP mean model with k_dlas DLAs intervening.
+    :return dla_M: (n_points, k), the GP covariance with k_dlas DLAs intervening.
+    :return dla_omega2: (n_points), the absorption noise with k_dlas DLAs intervening.S
+
+    Note: the number of Voigt profile lines is controlled by self.params : Parameters,
+    I prefer to not to allow users to change from the function arguments since that
+    would easily cause inconsistent within a pipeline. But if a user want to change
+    the num_lines, they can change via changing the instance attr of the self.params:Parameters
+    like:
+        self.params.num_lines = <the number of lines preferred to be used>
+    This would happen when a user want to know whether the result would converge with increasing
+    number of lines.
+    """
+    cdef int k_dlas = z_dlas.shape[0]
+    
+    cdef int length = padded_wavelengths.shape[0] - 6 # 2 * width
+    cdef int this_length = this_mu.shape[0]
+    cdef int this_k = this_M.shape[1]
+
+    cdef double[:] absorption = np.zeros(length)
+    cdef double[:] dla_mu = np.zeros(this_length)
+    cdef double[:, :] dla_M = np.zeros((this_length, this_k))
+    cdef double[:] dla_omega2 = np.zeros(this_length)
+    cdef double[:] this_absorption = np.zeros(this_length)
+
+    cdef int i,j,k
+
+
+    # absorption corresponding to this sample
+    absorption = voigt_absorption(
+        padded_wavelengths,
+        z_dla=z_dlas[0],
+        nhi=nhis[0],
+        num_lines=num_lines,
+    )
+
+    # absorption corresponding to other DLAs in multiple DLA samples
+    for i in range(1, k_dlas):
+        absorption2 = voigt_absorption(
+            padded_wavelengths,
+            z_dla=z_dlas[i],
+            nhi=nhis[i],
+            num_lines=num_lines,
+        )
+        for j in range(length):
+            absorption[j] = absorption[j] * absorption2[j]
+
+    # this_absorption[:] = absorption[mask_ind]
+    for i in range(this_length):
+        k = mask_index[i]
+        this_absorption[i] = absorption[k]
+
+    for i in range(this_length):
+        dla_mu[i] = this_mu[i] * this_absorption[i]
+        dla_omega2[i] = this_omega2[i] * this_absorption[i] ** 2
+
+    for i in range(this_length):
+        for j in range(this_k):
+            dla_M[i, j] = this_M[i, j] * this_absorption[i]
+
+    return dla_mu, dla_M, dla_omega2
+
+def sample_log_likelihood_k_dlas(
+    double[:] y,
+    double[:] v,
+    double[:] z_dlas,
+    double[:] nhis,
+    double[:] padded_wavelengths,
+    double[:] this_mu,
+    double[:, :] this_M,
+    double[:] this_omega2,
+    long[:] mask_index, # np.where(mask_ind)[0]
+    int num_lines,
+):
+    """
+    Compute the log likelihood of k DLAs within a quasar spectrum:
+        p(y | λ, σ², M, ω, c₀, τ₀, β, τ_kim, β_kim, {z_dla, logNHI}_{i=1}^k)
+
+    :param z_dlas: an array of z_dlas you want to condition on
+    :param nhis: an array of nhis you want to condition on
+    """
+    cdef int this_length = this_mu.shape[0]
+    cdef int this_k = this_M.shape[1]
+
+    cdef double[:] dla_mu = np.zeros(this_length)
+    cdef double[:, :] dla_M = np.zeros((this_length, this_k))
+    cdef double[:] dla_omega2 = np.zeros(this_length)
+
+    cdef double[:] d = np.zeros(this_length)
+
+    cdef double sample_log_likelihood
+
+    dla_mu, dla_M, dla_omega2 = this_dla_gp(
+        z_dlas,
+        nhis,
+        padded_wavelengths,
+        this_mu,
+        this_M, 
+        this_omega2,
+        mask_index,
+        num_lines
+    )
+
+    for i in range(this_length):
+        d[i] = dla_omega2[i] + v[i]
+
+    sample_log_likelihood = NullGP.log_mvnpdf_low_rank(
+        np.asarray(y), np.asarray(dla_mu), np.asarray(dla_M), np.asarray(d)
+    )
+
+    return sample_log_likelihood
+
+# the major for loop for QMC sampling
+def log_model_evidences(
+    double[:] y,
+    double[:] v,
+    int max_dlas,
+    int num_dla_samples,
+    double[:] sample_z_dlas,
+    double[:] nhi_samples,
+    double[:] padded_wavelengths,
+    double[:] this_mu,
+    double[:, :] this_M,
+    double[:] this_omega2,
+    long[:] mask_index, # np.where(mask_ind)[0]
+    int num_lines,
+    double min_z_separation
+):
+    """
+    marginalize out the DLA parameters, {(z_dla_i, logNHI_i)}_{i=1}^k_dlas,
+    and return an array of log_model_evidences for 1:k DLA models
+    
+    Note: we provide an integration method here to reproduce the functionality
+    in Ho-Bird-Garnett's code, but we encourage users to improve this sampling
+    scheme to be more efficient with another external script by calling
+    self.sample_log_likelihood_k_dlas directly.
+
+    :param max_dlas: the number of DLAs we want to marginalise
+
+    :return: [P(D | 1 DLA), ..., P(D | k DLAs)]
+    """
+    cdef int i, j, k, num_dlas, ind, base_ind
+    cdef double occams_factor = np.log(num_dla_samples)
+    # prepare the samples to be fed into the sample_log_likelihood function
+    cdef double[:] z_dlas = np.zeros((max_dlas, ))
+    cdef double[:] nhis = np.zeros((max_dlas, ))
+    cdef double z_dla_1, z_dla_2
+
+    # allocate the final log model evidences
+    cdef double[:] log_likelihoods_dla = np.empty((max_dlas, )) 
+    for i in range(max_dlas):
+        log_likelihoods_dla[:] = np.nan
+
+    # base inds to store the QMC samples to be resampled according
+    # the prior, which is the posterior of the previous run.
+    cdef int[:, :] base_sample_inds = np.zeros((max_dlas - 1, num_dla_samples), dtype=np.intc)
+
+    # sorry, let me follow the convention of the MATLAB code here
+    # could be changed to (max_dlas, num_dla_samples) in the future.
+    cdef double[:, :] sample_log_likelihoods = np.empty((num_dla_samples, max_dlas))
+    for i in range(num_dla_samples):
+        for j in range(max_dlas):
+            sample_log_likelihoods[i, j] = np.nan
+
+    # compute probabilities under DLA model for each of the sampled
+    # (normalized offset, log(N HI)) pairs
+    for num_dlas in range(max_dlas):  # count from zero to max_dlas - 1
+
+        # [Need to be parallelized]
+        # Roman's code has this part to be parallelized.
+        # for i in prange(num_dla_samples, nogil=True):
+        for i in range(num_dla_samples):        
+            # query the 1st DLA parameter {z_dla, logNHI}_{i=1} from the
+            # given DLA samples.
+            for j in range(num_dlas + 1):
+                if j == 0:
+                    z_dlas[j] = sample_z_dlas[i]
+                    nhis[j] = nhi_samples[i]
+                # query the 2:k DLA parameters {z_dla, logNHI}_{i=2}^k_dlas
+                else:
+                    base_ind = base_sample_inds[j-1, i]
+
+                    # append to samples to be applied on calculating the log likelihood
+                    z_dlas[j] = sample_z_dlas[base_ind]
+                    nhis[j] = nhi_samples[base_ind]
+
+            # store the sample log likelihoods conditioned on k-DLAs
+            sample_log_likelihoods[i, num_dlas] = sample_log_likelihood_k_dlas(
+                y,
+                v,
+                z_dlas[:(num_dlas+1)],
+                nhis[:(num_dlas+1)],
+                padded_wavelengths,
+                this_mu,
+                this_M,
+                this_omega2,
+                mask_index,
+                num_lines                                
+            )
+
+        # check if any pair of dlas in this sample is too close this has to
+        # happen outside the parfor because "continue" slows things down
+        # dramatically
+        if num_dlas > 0:
+            for i in range(num_dla_samples):
+                if find_min_z_separation(
+                    i,
+                    num_dlas,
+                    num_dla_samples,
+                    sample_z_dlas,
+                    base_sample_inds,
+                    min_z_separation
+                ):
+                    sample_log_likelihoods[i, num_dlas] = np.nan
+
+        # back to use numpy arrays; should be fine since the computationally expensive part
+        # is in the above.
+
+        # to prevent numerical underflow
+        max_log_likelihood = np.nanmax( np.asarray( sample_log_likelihoods[:, num_dlas]) )
+
+        sample_probabilities = np.exp(
+            np.asarray( sample_log_likelihoods[:, num_dlas]) - max_log_likelihood
+        )
+
+        log_likelihoods_dla[num_dlas] = (
+            max_log_likelihood
+            + np.log(np.nanmean(sample_probabilities))
+            - occams_factor * (num_dlas + 1) # additional + 1
+        )  # occams razor for more DLA parameters
+
+        # no needs for re-sample the QMC samples for the last run
+        if (num_dlas + 1) == max_dlas:
+            break
+
+        # if p(D | z_QSO, k DLA) is NaN, then
+        # finish the loop.
+        # It's usually because p(D | z_QSO, no DLA) is very high, so
+        # the higher order DLA model likelihoods already underflowed
+        if np.isnan(log_likelihoods_dla[num_dlas]):
+            print(
+                "Finish the loop earlier because NaN value in log p(D | z_QSO, {} DLAs)".format(
+                    num_dlas
+                )
+            )
+            break
+
+        # avoid nan values in the randsample weights
+        nanind = np.isnan(sample_probabilities)
+        W = sample_probabilities
+        W[nanind] = 0.0
+
+        resampled_base_sample_ind = np.random.choice(
+            np.arange(num_dla_samples).astype(np.int32),
+            size=num_dla_samples,
+            replace=True,
+            p=W / W.sum(),
+        )
+
+        for i in range(num_dla_samples):
+            base_sample_inds[num_dlas, i] = resampled_base_sample_ind[i]
+
+    return log_likelihoods_dla, sample_log_likelihoods
+
+def find_min_z_separation(
+    int i,
+    int num_dlas,
+    int num_dla_samples,
+    double[:] sample_z_dlas,
+    int[:, :] base_sample_inds,
+    double min_z_separation,
+):
+    cdef int j, k, ind
+    cdef double z_dla_1, z_dla_2
+
+    for j in range(num_dlas + 1):
+        # query the first DLA location
+        if j == 0:
+            z_dla_1 = sample_z_dlas[i]
+        else:
+            ind = base_sample_inds[j-1, i]
+            z_dla_1 = sample_z_dlas[ind]
+
+        for k in range(j + 1, num_dlas + 1):
+            # query the second DLA location
+            ind = base_sample_inds[k-1, i]
+            z_dla_2 = sample_z_dlas[ind]
+
+            if np.abs(z_dla_1 - z_dla_2) < min_z_separation:
+                return True
+
+    return False

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,21 @@
+from distutils.core import setup
+from Cython.Build import cythonize
+from distutils.extension import Extension
+from Cython.Distutils import build_ext
+
+ext_modules=[
+    Extension("fast_dla_log_model_evidence",
+              ["gpy_dla_detection/fast_dla_log_model_evidence.pyx"],
+              libraries=["m"],
+              extra_compile_args = ["-O3", "-ffast-math", "-march=native", "-fopenmp" ],
+              extra_link_args=['-fopenmp']
+    ) 
+]
+
+setup( 
+  name = "DLA_log_model_evidence",
+  cmdclass = {"build_ext": build_ext},
+  ext_modules = ext_modules
+)
+
+# setup(name="DLA log model evidence", ext_modules=cythonize('gpy_dla_detection/fast_dla_log_model_evidence.pyx'),)

--- a/tests/test_cython.py
+++ b/tests/test_cython.py
@@ -1,0 +1,198 @@
+'''
+Test the Cython functions
+'''
+import os
+import time
+import numpy as np
+from gpy_dla_detection.set_parameters import Parameters
+from gpy_dla_detection.model_priors import PriorCatalog
+from gpy_dla_detection.null_gp import NullGPMAT
+from gpy_dla_detection.dla_gp import DLAGPMAT
+from gpy_dla_detection.read_spec import read_spec, retrieve_raw_spec
+from gpy_dla_detection.dla_samples import DLASamplesMAT
+
+from fast_dla_log_model_evidence import this_dla_gp, sample_log_likelihood_k_dlas, log_model_evidences
+
+def test_this_dla_profile():
+    # test 1
+    filename = "spec-5309-55929-0362.fits"
+
+    if not os.path.exists(filename):
+        retrieve_raw_spec(5309, 55929, 362)  # the spectrum at paper
+
+    z_qso = 3.166
+
+    param = Parameters()
+
+    # prepare these files by running the MATLAB scripts until build_catalog.m
+    prior = PriorCatalog(
+        param,
+        "data/dr12q/processed/catalog.mat",
+        "data/dla_catalogs/dr9q_concordance/processed/los_catalog",
+        "data/dla_catalogs/dr9q_concordance/processed/dla_catalog",
+    )
+    dla_samples = DLASamplesMAT(
+        param, prior, "data/dr12q/processed/dla_samples_a03.mat"
+    )
+
+    wavelengths, flux, noise_variance, pixel_mask = read_spec(filename)
+    rest_wavelengths = param.emitted_wavelengths(wavelengths, z_qso)
+
+    # DLA GP Model
+    dla_gp = DLAGPMAT(
+        param,
+        prior,
+        dla_samples,
+        3000.0,
+        "data/dr12q/processed/learned_qso_model_lyseries_variance_kim_dr9q_minus_concordance.mat",
+    )
+    dla_gp.set_data(
+        rest_wavelengths, flux, noise_variance, pixel_mask, z_qso, build_model=True
+    )
+
+    # These are the MAPs from the paper
+    z_dlas = np.array([2.52182382, 3.03175723])
+    nhis = 10 ** np.array([20.63417494, 22.28420156])
+
+    # prepare arrays
+    padded_wavelengths = dla_gp.padded_wavelengths
+    this_mu = dla_gp.this_mu
+    this_M = dla_gp.this_M
+    this_omega2 = dla_gp.this_omega2
+    mask_index = np.where(~dla_gp.pixel_mask[dla_gp.ind])[0]
+    num_lines = dla_gp.params.num_lines
+
+    dla_mu, dla_M, dla_omega2 = this_dla_gp(
+        z_dlas, nhis, padded_wavelengths, this_mu, this_M, this_omega2, mask_index, num_lines)
+
+    dla_mu = np.asarray(dla_mu)
+    dla_M = np.asarray(dla_M)
+    dla_omega2 = np.asarray(dla_omega2)
+
+    dla_mu2, dla_M2, dla_omega22 = dla_gp.this_dla_gp(z_dlas, nhis)
+
+    assert np.all(np.abs(dla_mu - dla_mu2) < 1e-4)
+    assert np.all(np.abs(dla_M - dla_M2) < 1e-4)
+    assert np.all(np.abs(dla_omega2 - dla_omega22) < 1e-4)
+
+    # calculate log sample likelihood
+    y = dla_gp.y.astype(np.double)
+    v = dla_gp.v.astype(np.double)
+
+    # naive timeit
+    tic = time.time()
+    for i in range(100):
+        sample_log_likelihood = sample_log_likelihood_k_dlas(
+            y, v, z_dlas, nhis, padded_wavelengths, this_mu, this_M, this_omega2, mask_index, num_lines
+        )
+        time_spent = time.time() - tic
+        tic = time.time()
+    print("Spent {:.5g} with Cython".format(time_spent / 50))
+
+    tic = time.time()
+    for i in range(100):
+        sample_log_likelihood2 = dla_gp.sample_log_likelihood_k_dlas(z_dlas, nhis)
+        time_spent = time.time() - tic
+        tic = time.time()
+    print("Spent {:.5g} with Native python".format(time_spent / 50))
+
+    assert np.abs(sample_log_likelihood - sample_log_likelihood2) < 1e-4
+
+def test_log_model_evidences():
+    # test 1
+    filename = "spec-5309-55929-0362.fits"
+
+    if not os.path.exists(filename):
+        retrieve_raw_spec(5309, 55929, 362)  # the spectrum at paper
+
+    z_qso = 3.166
+
+    param = Parameters()
+
+    # prepare these files by running the MATLAB scripts until build_catalog.m
+    prior = PriorCatalog(
+        param,
+        "data/dr12q/processed/catalog.mat",
+        "data/dla_catalogs/dr9q_concordance/processed/los_catalog",
+        "data/dla_catalogs/dr9q_concordance/processed/dla_catalog",
+    )
+    dla_samples = DLASamplesMAT(
+        param, prior, "data/dr12q/processed/dla_samples_a03.mat"
+    )
+
+    wavelengths, flux, noise_variance, pixel_mask = read_spec(filename)
+    rest_wavelengths = param.emitted_wavelengths(wavelengths, z_qso)
+
+    # DLA GP Model
+    dla_gp = DLAGPMAT(
+        param,
+        prior,
+        dla_samples,
+        3000.0,
+        "data/dr12q/processed/learned_qso_model_lyseries_variance_kim_dr9q_minus_concordance.mat",
+    )
+    dla_gp.set_data(
+        rest_wavelengths, flux, noise_variance, pixel_mask, z_qso, build_model=True
+    )
+
+    # prepare arrays
+    # model inputs
+    this_mu = dla_gp.this_mu
+    this_M = dla_gp.this_M
+    this_omega2 = dla_gp.this_omega2
+    num_lines = dla_gp.params.num_lines
+
+    # data input
+    y = dla_gp.y.astype(np.double)
+    v = dla_gp.v.astype(np.double)
+    mask_index = np.where(~dla_gp.pixel_mask[dla_gp.ind])[0]
+    padded_wavelengths = dla_gp.padded_wavelengths
+
+    # multi-DLA min separation
+    min_z_separation = dla_gp.min_z_separation
+    
+    # DLA sampling part
+    sample_z_dlas = dla_gp.dla_samples.sample_z_dlas(dla_gp.this_wavelengths, dla_gp.z_qso)
+    nhi_samples = dla_gp.dla_samples.nhi_samples
+    num_dla_samples = dla_gp.dla_samples.num_dla_samples
+
+    tic = time.time()
+
+    # test the Cython sample function
+    max_dlas = 4
+    log_likelihoods_dla, sample_log_likelihoods = log_model_evidences(
+        y,
+        v,
+        max_dlas,
+        num_dla_samples,
+        sample_z_dlas,
+        nhi_samples,
+        padded_wavelengths,
+        this_mu,
+        this_M,
+        this_omega2,
+        mask_index, # np.where(mask_ind)[0]
+        num_lines,
+        min_z_separation
+    )
+
+    toc = time.time()
+    # very time consuming: ~ 4 mins for a single spectrum without parallelized.
+    print("spent {} mins; {} seconds".format((toc - tic) // 60, (toc - tic) % 60))
+
+    log_likelihoods_dla = np.asarray(log_likelihoods_dla)
+
+    # log likelihood results from the catalog
+    catalog_log_likelihoods_dla = np.array(
+        [-688.91647288, -633.00070813, -634.08569242, -640.77120558]
+    )
+
+    for i in range(max_dlas):
+        print(
+            "log p(  D  | z_QSO, DLA{} ) : {:.5g}; MATLAB value: {:.5g}".format(
+                i + 1, log_likelihoods_dla[i], catalog_log_likelihoods_dla[i]
+            )
+        )
+
+    # the accuracy down to 2.5 in log scale, this needs to be investigated.
+    assert np.all(np.abs(catalog_log_likelihoods_dla - log_likelihoods_dla) < 2.5)


### PR DESCRIPTION
I roughly wrote the code into Cython, but due to I used too many scipy functions and convert too many arrays using np.asarray so the speed did not go up (I believe so!).

Also, due to `prange` couldn't be opened, OpenMP is not activated.

The speed now is ~ 5 mins per spectrum on my laptop, which is 1 min slower than pure-python version :crying_cat_face: 

I think we need to write:

- [ ] `log_mvnpdf_low_rank` into full Cython 
- [ ] `voigt_absorption` in to full Cython

in order to activate OpenMP.

But apparently this would not be an easy thing to do since we need to find Cython version of `chol` and `solve_triangle` otherwise we need to do it by hand.
So I put this implementation to be in a lower priority now.
