### PR TITLE
[In Progress] Improve log_mvnpdf_low_rank function

### DIFF
--- a/gpy_dla_detection/dla_gp.py
+++ b/gpy_dla_detection/dla_gp.py
@@ -79,7 +79,7 @@ class DLAGP(NullGP):
 
         self.dla_samples = dla_samples
 
-    def log_model_evidences(self, max_dlas: int) -> np.ndarray:
+    def log_model_evidences(self, max_dlas: int, scipy_lapack: bool = False) -> np.ndarray:
         """
         marginalize out the DLA parameters, {(z_dla_i, logNHI_i)}_{i=1}^k_dlas,
         and return an array of log_model_evidences for 1:k DLA models
@@ -143,7 +143,7 @@ class DLAGP(NullGP):
 
                 # store the sample log likelihoods conditioned on k-DLAs
                 sample_log_likelihoods[i, num_dlas] = self.sample_log_likelihood_k_dlas(
-                    z_dlas, nhis
+                    z_dlas, nhis, scipy_lapack=scipy_lapack
                 ) - np.log(
                     self.params.num_dla_samples
                 )  # additional occams razor
@@ -215,7 +215,8 @@ class DLAGP(NullGP):
 
     @profile
     def sample_log_likelihood_k_dlas(
-        self, z_dlas: np.ndarray, nhis: np.ndarray
+        self, z_dlas: np.ndarray, nhis: np.ndarray, 
+        scipy_lapack: bool = False
     ) -> float:
         """
         Compute the log likelihood of k DLAs within a quasar spectrum:
@@ -229,7 +230,7 @@ class DLAGP(NullGP):
         dla_mu, dla_M, dla_omega2 = self.this_dla_gp(z_dlas, nhis)
 
         sample_log_likelihood = self.log_mvnpdf_low_rank(
-            self.y, dla_mu, dla_M, dla_omega2 + self.v
+            self.y, dla_mu, dla_M, dla_omega2 + self.v, scipy_lapack
         )
 
         return sample_log_likelihood

--- a/gpy_dla_detection/dla_gp.py
+++ b/gpy_dla_detection/dla_gp.py
@@ -15,6 +15,7 @@ from .voigt import voigt_absorption
 # I import this is for the convenient of my autocomplete
 from .dla_samples import DLASamplesMAT
 
+from profilehooks import profile
 
 class DLAGP(NullGP):
     """
@@ -212,6 +213,7 @@ class DLAGP(NullGP):
 
         return log_likelihoods_dla
 
+    @profile
     def sample_log_likelihood_k_dlas(
         self, z_dlas: np.ndarray, nhis: np.ndarray
     ) -> float:

--- a/log_mvnpdf_low_rank.py
+++ b/log_mvnpdf_low_rank.py
@@ -1,0 +1,96 @@
+import numpy as np
+import scipy
+import scipy.linalg
+from profilehooks import profile
+
+from gpy_dla_detection.set_parameters import Parameters
+from gpy_dla_detection.model_priors import PriorCatalog
+from gpy_dla_detection.dla_gp import DLAGPMAT
+from gpy_dla_detection.dla_samples import DLASamplesMAT
+from gpy_dla_detection.read_spec import read_spec
+
+@profile
+def log_mvnpdf_low_rank(
+    y: np.ndarray, mu: np.ndarray, M: np.ndarray, d: np.ndarray
+) -> float:
+    """
+    efficiently computes
+    
+        log N(y; mu, MM' + diag(d))
+    
+    :param y: this_flux, (n_points, )
+    :param mu: this_mu, the mean vector of GP, (n_points, )
+    :param M: this_M, the low rank decomposition of covariance matrix, (n_points, k)
+    :param d: diagonal noise term, (n_points, )
+    """
+    log_2pi = 1.83787706640934534
+
+    n, k = M.shape
+
+    y = y[:, None] - mu[:, None]
+
+    d_inv = 1 / d[:, None]  # (n_points, 1)
+    D_inv_y = d_inv * y  # (n_points, 1)
+    D_inv_M = d_inv * M  # (n_points, k)
+
+    # use Woodbury identity, define
+    #   B = (I + M' D^-1 M),
+    # then
+    #   K^-1 = D^-1 - D^-1 M B^-1 M' D^-1
+    B = np.matmul(M.T, D_inv_M)  # (k, n_points) * (n_points, k) -> (k, k)
+    # add the identity matrix with magic indicing
+    B.ravel()[0 :: (k + 1)] = B.ravel()[0 :: (k + 1)] + 1
+    # numpy cholesky returns lower triangle, different than MATLAB's upper triangle
+    L = np.linalg.cholesky(B)
+    # C = B^-1 M' D^-1
+    tmp = scipy.linalg.solve_triangular(L, D_inv_M.T, lower=True)  # (k, n_points)
+    C = scipy.linalg.solve_triangular(L.T, tmp, lower=False)  # (k, n_points)
+
+    K_inv_y = D_inv_y - np.matmul(D_inv_M, np.matmul(C, y))  # (n_points, 1)
+
+    log_det_K = np.sum(np.log(d)) + 2 * np.sum(np.log(np.diag(L)))
+
+    log_p = -0.5 * (np.matmul(y.T, K_inv_y).sum() + log_det_K + n * log_2pi)
+
+    return log_p
+
+if __name__ == "__main__":
+    # y = np.array([1, 2])
+    # mu = np.array([1, 2])
+    # M = np.array([[2, 3, 1], [1, 2, 4]])
+    # d = np.eye(2) * 2
+
+    # test 1
+    filename = "spec-5309-55929-0362.fits"
+
+    z_qso = 3.166
+
+    param = Parameters()
+
+    # prepare these files by running the MATLAB scripts until build_catalog.m
+    prior = PriorCatalog(
+        param,
+        "data/dr12q/processed/catalog.mat",
+        "data/dla_catalogs/dr9q_concordance/processed/los_catalog",
+        "data/dla_catalogs/dr9q_concordance/processed/dla_catalog",
+    )
+    dla_samples = DLASamplesMAT(
+        param, prior, "data/dr12q/processed/dla_samples_a03.mat"
+    )
+
+    wavelengths, flux, noise_variance, pixel_mask = read_spec(filename)
+    rest_wavelengths = param.emitted_wavelengths(wavelengths, z_qso)
+
+    # DLA GP Model
+    dla_gp = DLAGPMAT(
+        param,
+        prior,
+        dla_samples,
+        3000.0,
+        "data/dr12q/processed/learned_qso_model_lyseries_variance_kim_dr9q_minus_concordance.mat",
+    )
+    dla_gp.set_data(
+        rest_wavelengths, flux, noise_variance, pixel_mask, z_qso, build_model=True
+    )
+
+    print(log_mvnpdf_low_rank(dla_gp.y, dla_gp.this_mu, dla_gp.M, dla_gp.v + dla_gp.this_omega2))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -210,7 +210,7 @@ def test_dla_model():
     assert sample_log_likelihood_dla > log_likelihood_no_dla
 
 
-def test_dla_model_evidences():
+def test_dla_model_evidences(scipy_lapack: bool = False):
     # test 1
     filename = "spec-5309-55929-0362.fits"
 
@@ -250,7 +250,7 @@ def test_dla_model_evidences():
     tic = time.time()
 
     max_dlas = 4
-    log_likelihoods_dla = dla_gp.log_model_evidences(max_dlas)
+    log_likelihoods_dla = dla_gp.log_model_evidences(max_dlas, scipy_lapack=scipy_lapack)
 
     toc = time.time()
     # very time consuming: ~ 4 mins for a single spectrum without parallelized.


### PR DESCRIPTION
Now the calculation of log_model_evidences of mult-DLA model costs ~4mins for 10000 samples.

It seems there are some rooms to improve the log-likelihood calculation:

```
*** PROFILER RESULTS ***
log_mvnpdf_low_rank (log_mvnpdf_low_rank.py:12)
function called 1 times

         149 function calls (148 primitive calls) in 0.009 seconds

   Ordered by: cumulative time, internal time, call count
   List reduced from 57 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.001    0.001    0.009    0.009 log_mvnpdf_low_rank.py:12(log_mvnpdf_low_rank)
        2    0.008    0.004    0.009    0.004 basic.py:259(solve_triangular)
        4    0.000    0.000    0.000    0.000 _util.py:217(_asarray_validated)
      5/4    0.000    0.000    0.000    0.000 {built-in method numpy.core._multiarray_umath.implement_array_function}
        4    0.000    0.000    0.000    0.000 function_base.py:422(asarray_chkfinite)
        2    0.000    0.000    0.000    0.000 blas.py:370(getter)
        7    0.000    0.000    0.000    0.000 {method 'reduce' of 'numpy.ufunc' objects}
        1    0.000    0.000    0.000    0.000 <__array_function__ internals>:2(cholesky)
        2    0.000    0.000    0.000    0.000 lapack.py:854(get_lapack_funcs)
        2    0.000    0.000    0.000    0.000 blas.py:317(_get_funcs)
        1    0.000    0.000    0.000    0.000 linalg.py:673(cholesky)
        2    0.000    0.000    0.000    0.000 <__array_function__ internals>:2(sum)
        2    0.000    0.000    0.000    0.000 fromnumeric.py:2105(sum)
        4    0.000    0.000    0.000    0.000 {method 'all' of 'numpy.ndarray' objects}
        2    0.000    0.000    0.000    0.000 fromnumeric.py:70(_wrapreduction)
        4    0.000    0.000    0.000    0.000 _methods.py:56(_all)
        1    0.000    0.000    0.000    0.000 <__array_function__ internals>:2(diag)
        2    0.000    0.000    0.000    0.000 blas.py:252(find_best_blas_type)
        1    0.000    0.000    0.000    0.000 twodim_base.py:214(diag)
        1    0.000    0.000    0.000    0.000 {method 'sum' of 'numpy.ndarray' objects}
        1    0.000    0.000    0.000    0.000 <__array_function__ internals>:2(diagonal)
        1    0.000    0.000    0.000    0.000 fromnumeric.py:1502(diagonal)
        1    0.000    0.000    0.000    0.000 _methods.py:45(_sum)
        7    0.000    0.000    0.000    0.000 {built-in method numpy.array}
        5    0.000    0.000    0.000    0.000 _asarray.py:14(asarray)
        1    0.000    0.000    0.000    0.000 linalg.py:135(_commonType)
        1    0.000    0.000    0.000    0.000 linalg.py:107(_makearray)
       15    0.000    0.000    0.000    0.000 {method 'get' of 'dict' objects}
        4    0.000    0.000    0.000    0.000 {built-in method builtins.getattr}
        4    0.000    0.000    0.000    0.000 base.py:1188(isspmatrix)
        4    0.000    0.000    0.000    0.000 core.py:6374(isMaskedArray)
        2    0.000    0.000    0.000    0.000 blas.py:299(<listcomp>)
       13    0.000    0.000    0.000    0.000 {built-in method builtins.isinstance}
        6    0.000    0.000    0.000    0.000 {built-in method builtins.len}
        2    0.000    0.000    0.000    0.000 {built-in method builtins.max}
        1    0.000    0.000    0.000    0.000 linalg.py:102(get_linalg_error_extobj)
        1    0.000    0.000    0.000    0.000 {method 'astype' of 'numpy.ndarray' objects}
        1    0.000    0.000    0.000    0.000 {method 'diagonal' of 'numpy.ndarray' objects}
        1    0.000    0.000    0.000    0.000 linalg.py:125(_realType)
        2    0.000    0.000    0.000    0.000 _asarray.py:86(asanyarray)
```

It looks like the solve_triangular function spent 0.008 seconds, this means 80 seconds for 10000 samples and 320 seconds for 4-DLA model. I think if we can improve this then the performance can go up.